### PR TITLE
Add compatibility with Guzzle 6.

### DIFF
--- a/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
@@ -64,6 +64,9 @@ class GoutteDriverFactory implements IMinkDriverFactory
 		if ( $this->_isGoutte1() ) {
 			$guzzle_client = $this->_buildGuzzle3Client($driver_options['guzzle_parameters']);
 		}
+		elseif ( $this->_isGuzzle6() ) {
+			$guzzle_client = $this->_buildGuzzle6Client($driver_options['guzzle_parameters']);
+		}
 		else {
 			$guzzle_client = $this->_buildGuzzle4Client($driver_options['guzzle_parameters']);
 		}
@@ -72,6 +75,23 @@ class GoutteDriverFactory implements IMinkDriverFactory
 		$goutte_client->setClient($guzzle_client);
 
 		return new \Behat\Mink\Driver\GoutteDriver($goutte_client);
+	}
+
+	/**
+	 * Builds Guzzle 6 client.
+	 *
+	 * @param array $parameters Parameters.
+	 *
+	 * @return \GuzzleHttp\Client
+	 */
+	private function _buildGuzzle6Client(array $parameters)
+	{
+		// Force the parameters set by default in Goutte to reproduce its behavior.
+		$parameters['allow_redirects'] = false;
+		$parameters['cookies'] = true;
+
+		return new \GuzzleHttp\Client($parameters);
+
 	}
 
 	/**
@@ -121,5 +141,16 @@ class GoutteDriverFactory implements IMinkDriverFactory
 
 		return false;
 	}
+	
+	/**
+	 * Determines Guzzle version.
+	 *
+	 * @return boolean
+	 */
+	private function _isGuzzle6()
+        {
+        	return interface_exists('GuzzleHttp\ClientInterface') && 
+        	version_compare(\GuzzleHttp\ClientInterface::VERSION, '6.0.0', '>=');
+        }
 
 }

--- a/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
@@ -148,9 +148,9 @@ class GoutteDriverFactory implements IMinkDriverFactory
 	 * @return boolean
 	 */
 	private function _isGuzzle6()
-        {
-        	return interface_exists('GuzzleHttp\ClientInterface') && 
-        	version_compare(\GuzzleHttp\ClientInterface::VERSION, '6.0.0', '>=');
-        }
+	{
+		return interface_exists('GuzzleHttp\ClientInterface') && 
+		version_compare(\GuzzleHttp\ClientInterface::VERSION, '6.0.0', '>=');
+	}
 
 }


### PR DESCRIPTION
This reflects the update on MinkExtension: https://github.com/Behat/MinkExtension/pull/236

Guzzle 6 no longer expects a nested array for the default configuration.
